### PR TITLE
#167166967 Display button to go back to home page on mobile

### DIFF
--- a/src/Components/NavBar/NavBar.jsx
+++ b/src/Components/NavBar/NavBar.jsx
@@ -15,6 +15,7 @@ import SearchBox from '../Common/SearchBox/SearchBox';
 import Button from '../Common/Button/Button';
 import * as paths from '../../paths';
 import ProfileDropdown from '../Common/Profile/ProfileDropdown';
+import logoImg from '../../assets/img/logo_ah.png';
 
 /**
  * Render the NavBar
@@ -144,6 +145,19 @@ export class NavBar extends Component {
   }
 
   /**
+   * Go back home
+   * @returns {object} jsx
+   * @memberof NavBar
+   */
+  renderGoHome() {
+    return (
+      <a href="/" className="ml-2 logo-container">
+        <img className="mobile-logo" src={logoImg} alt="author haven logo" />
+      </a>
+    );
+  }
+
+  /**
    * render navbar
    * @param {*} isAuth
    * @param {*} notificationsCount
@@ -157,13 +171,20 @@ export class NavBar extends Component {
     const {
       location: { state: searchParams = {} },
     } = this.props;
+    const { match } = this.props;
     return (
       <React.Fragment>
         <Navbar fixed="top" className="flex-nowrap flex-row" expand="lg" variant="dark">
           <Navbar.Brand className="d-none mr-md-auto d-md-block">
             <Logo />
           </Navbar.Brand>
-          {this.renderHamburgerIcon(faBars)}
+          {mobileDetect.isMobile() &&
+          (this.pathname === paths.HOME_PATH ||
+            this.pathname === '/not-found' ||
+            this.pathname === `/articles/${match.params.slug}` ||
+            this.pathname === '/search')
+            ? this.renderGoHome()
+            : this.renderHamburgerIcon(faBars)}
           {this.displaySearchBox ? (
             <Nav className="mr-auto search-container">
               <SearchBox
@@ -225,6 +246,7 @@ export const mapDispatchToProps = dispatch => ({
 });
 
 NavBar.propTypes = {
+  match: PropTypes.any,
   onToggleSideNav: PropTypes.func.isRequired,
   navbar: PropTypes.object.isRequired,
   currentUser: PropTypes.object.isRequired,
@@ -235,6 +257,7 @@ NavBar.propTypes = {
 };
 
 NavBar.defaultProps = {
+  match: {},
   displaySearchBox: true,
 };
 

--- a/src/Components/NavBar/NavBar.scss
+++ b/src/Components/NavBar/NavBar.scss
@@ -8,6 +8,14 @@
     width: 40%;
   }
 
+  .logo-container {
+    cursor: pointer;
+    .mobile-logo {
+      width: 43px;
+      height: 40px;
+    }
+  }
+
   #dropdown-basic {
     .dropdown-menu {
       position: absolute;

--- a/src/__test__/component/NavBar.test.js
+++ b/src/__test__/component/NavBar.test.js
@@ -50,6 +50,7 @@ describe('NavBar component', () => {
     const instance = wrapper.instance();
     instance.toggleSideNav(isDrawerDisplay);
     expect(props.onToggleSideNav).toHaveBeenCalled();
+    expect(instance.renderGoHome()).toBeDefined();
   });
 
   it('should map state to props', () => {


### PR DESCRIPTION
#### What does this PR do?
- Display button to go back to home page on mobile
#### Description of Task to be completed?
- detect if the user is on mobile
- display the back-home button on:
 ~ home-page,
 ~ search-page,
 ~ not-found-page and single-article page
#### How should this be manually tested?
- npm run test
#### Any background context you want to provide?

N/A

#### What are the relevant pivotal tracker stories?

[#167166967](https://www.pivotaltracker.com/story/show/167166967)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/25999336/60978739-e576bd80-a331-11e9-84f9-ba4df0daee18.png)

![image](https://user-images.githubusercontent.com/25999336/60978753-ea3b7180-a331-11e9-8b35-bd43f064cf31.png)

#### Questions:

N/A
